### PR TITLE
Upgrade select to SDK v2.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AWSClientConfig.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AWSClientConfig.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.thirdparty.org.apache.http.client.utils.URIBuilder;
 
 import org.apache.hadoop.conf.Configuration;
@@ -112,6 +113,33 @@ public final class AWSClientConfig {
   }
 
   /**
+   * Configures the async http client.
+   *
+   * @param conf The Hadoop configuration
+   * @return Http client builder
+   */
+  public static NettyNioAsyncHttpClient.Builder createAsyncHttpClientBuilder(Configuration conf) {
+    NettyNioAsyncHttpClient.Builder httpClientBuilder =
+        NettyNioAsyncHttpClient.builder();
+
+    httpClientBuilder.maxConcurrency(S3AUtils.intOption(conf, MAXIMUM_CONNECTIONS,
+        DEFAULT_MAXIMUM_CONNECTIONS, 1));
+
+    int connectionEstablishTimeout =
+        S3AUtils.intOption(conf, ESTABLISH_TIMEOUT, DEFAULT_ESTABLISH_TIMEOUT, 0);
+    int socketTimeout = S3AUtils.intOption(conf, SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT, 0);
+
+    httpClientBuilder.connectionTimeout(Duration.ofSeconds(connectionEstablishTimeout));
+    httpClientBuilder.readTimeout(Duration.ofSeconds(socketTimeout));
+    httpClientBuilder.writeTimeout(Duration.ofSeconds(socketTimeout));
+
+    // TODO: Need to set ssl socket factory, as done in
+    //  NetworkBinding.bindSSLChannelMode(conf, awsConf);
+
+    return httpClientBuilder;
+  }
+
+  /**
    * Configures the retry policy.
    *
    * @param conf The Hadoop configuration
@@ -182,6 +210,71 @@ public final class AWSClientConfig {
     }
 
     return proxyConfigBuilder;
+  }
+
+  /**
+   * Configures the proxy.
+   *
+   * @param conf The Hadoop configuration
+   * @param bucket Optional bucket to use to look up per-bucket proxy secrets
+   * @return Proxy configuration
+   * @throws IOException on any IO problem
+   */
+  public static software.amazon.awssdk.http.nio.netty.ProxyConfiguration
+      createAsyncProxyConfiguration(Configuration conf,
+      String bucket) throws IOException {
+
+    software.amazon.awssdk.http.nio.netty.ProxyConfiguration.Builder proxyConfigBuilder =
+        software.amazon.awssdk.http.nio.netty.ProxyConfiguration.builder();
+
+    String proxyHost = conf.getTrimmed(PROXY_HOST, "");
+    int proxyPort = conf.getInt(PROXY_PORT, -1);
+
+    if (!proxyHost.isEmpty()) {
+      if (proxyPort >= 0) {
+        proxyConfigBuilder.host(proxyHost);
+        proxyConfigBuilder.port(proxyPort);
+      } else {
+        if (conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS)) {
+          LOG.warn("Proxy host set without port. Using HTTPS default 443");
+          proxyConfigBuilder.host(proxyHost);
+          proxyConfigBuilder.port(443);
+        } else {
+          LOG.warn("Proxy host set without port. Using HTTP default 80");
+          proxyConfigBuilder.host(proxyHost);
+          proxyConfigBuilder.port(80);
+        }
+      }
+      final String proxyUsername = S3AUtils.lookupPassword(bucket, conf, PROXY_USERNAME,
+          null, null);
+      final String proxyPassword = S3AUtils.lookupPassword(bucket, conf, PROXY_PASSWORD,
+          null, null);
+      if ((proxyUsername == null) != (proxyPassword == null)) {
+        String msg = "Proxy error: " + PROXY_USERNAME + " or " +
+            PROXY_PASSWORD + " set without the other.";
+        LOG.error(msg);
+        throw new IllegalArgumentException(msg);
+      }
+      proxyConfigBuilder.username(proxyUsername);
+      proxyConfigBuilder.password(proxyPassword);
+      // TODO: check NTLM support
+      // proxyConfigBuilder.ntlmDomain(conf.getTrimmed(PROXY_DOMAIN));
+      // proxyConfigBuilder.ntlmWorkstation(conf.getTrimmed(PROXY_WORKSTATION));
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Using proxy server {}:{} as user {} with password {} on "
+                + "domain {} as workstation {}", proxyHost, proxyPort, proxyUsername, proxyPassword,
+            PROXY_DOMAIN, PROXY_WORKSTATION);
+      }
+    } else if (proxyPort >= 0) {
+      String msg =
+          "Proxy error: " + PROXY_PORT + " set without " + PROXY_HOST;
+      LOG.error(msg);
+      throw new IllegalArgumentException(msg);
+    } else {
+      return null;
+    }
+
+    return proxyConfigBuilder.build();
   }
 
   /***

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -50,13 +50,17 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.apache.ProxyConfiguration;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -263,6 +267,80 @@ public class DefaultS3ClientFactory extends Configured
     //  seems to have a metrics publisher.
 
     return s3ClientBuilder.build();
+  }
+
+  public S3AsyncClient createS3AsyncClient(
+      final URI uri,
+      final S3ClientCreationParameters parameters) throws IOException {
+
+    Configuration conf = getConf();
+    bucket = uri.getHost();
+
+    final ClientOverrideConfiguration.Builder clientOverrideConfigBuilder =
+        AWSClientConfig.createClientConfigBuilder(conf);
+
+    final NettyNioAsyncHttpClient.Builder asyncHttpClientBuilder =
+        AWSClientConfig.createAsyncHttpClientBuilder(conf);
+
+    final RetryPolicy.Builder retryPolicyBuilder = AWSClientConfig.createRetryPolicyBuilder(conf);
+
+    final software.amazon.awssdk.http.nio.netty.ProxyConfiguration proxyConfig =
+        AWSClientConfig.createAsyncProxyConfiguration(conf, bucket);
+
+    S3AsyncClientBuilder s3AsyncClientBuilder = S3AsyncClient.builder();
+
+    // add any headers
+    parameters.getHeaders().forEach((h, v) -> clientOverrideConfigBuilder.putHeader(h, v));
+
+    if (parameters.isRequesterPays()) {
+      // All calls must acknowledge requester will pay via header.
+      clientOverrideConfigBuilder.putHeader(REQUESTER_PAYS_HEADER, REQUESTER_PAYS_HEADER_VALUE);
+    }
+
+    if (!StringUtils.isEmpty(parameters.getUserAgentSuffix())) {
+      clientOverrideConfigBuilder.putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX,
+          parameters.getUserAgentSuffix());
+    }
+
+    if (parameters.getExecutionInterceptors() != null) {
+      for (ExecutionInterceptor interceptor : parameters.getExecutionInterceptors()) {
+        clientOverrideConfigBuilder.addExecutionInterceptor(interceptor);
+      }
+    }
+
+    clientOverrideConfigBuilder.retryPolicy(retryPolicyBuilder.build());
+    if (proxyConfig != null) {
+      asyncHttpClientBuilder.proxyConfiguration(proxyConfig);
+    }
+
+    s3AsyncClientBuilder.httpClientBuilder(asyncHttpClientBuilder)
+        .overrideConfiguration(clientOverrideConfigBuilder.build());
+
+    // use adapter classes so V1 credential providers continue to work. This will be moved to
+    // AWSCredentialProviderList.add() when that class is updated.
+    s3AsyncClientBuilder.credentialsProvider(
+        V1V2AwsCredentialProviderAdapter.adapt(parameters.getCredentialSet()));
+
+    URI endpoint = getS3Endpoint(parameters.getEndpoint(), conf);
+
+    Region region =
+        getS3Region(conf.getTrimmed(AWS_REGION), parameters.getCredentialSet());
+
+    LOG.debug("Using endpoint {}; and region {}", endpoint, region);
+
+    s3AsyncClientBuilder.endpointOverride(endpoint).region(region);
+
+    S3Configuration s3Configuration = S3Configuration.builder()
+        .pathStyleAccessEnabled(parameters.isPathStyleAccess())
+        .build();
+
+    s3AsyncClientBuilder.serviceConfiguration(s3Configuration);
+
+    // TODO: Some configuration done in configureBasicParams is not done yet.
+    //  Need to verify how metrics collection can be done, as SDK V2 only
+    //  seems to have a metrics publisher.
+
+    return s3AsyncClientBuilder.build();
   }
 
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.s3a.statistics.StatisticsFromAwsSdk;
 
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ENDPOINT;
@@ -76,6 +77,16 @@ public interface S3ClientFactory {
   S3Client createS3ClientV2(URI uri,
       S3ClientCreationParameters parameters) throws IOException;
 
+  /**
+   * Creates a new {@link S3AsyncClient}.
+   *
+   * @param uri S3A file system URI
+   * @param parameters parameter object
+   * @return Async S3 client
+   * @throws IOException on any IO problem
+   */
+  S3AsyncClient createS3AsyncClient(URI uri,
+      S3ClientCreationParameters parameters) throws IOException;
 
   /**
    * Settings for the S3 Client.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
@@ -25,15 +25,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.amazonaws.services.s3.model.SelectObjectContentRequest;
-import com.amazonaws.services.s3.model.SelectObjectContentResult;
-
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.MultipartUpload;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
@@ -41,6 +39,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.impl.PutObjectOptions;
+import org.apache.hadoop.fs.s3a.select.SelectEventStreamPublisher;
 import org.apache.hadoop.fs.store.audit.AuditSpanSource;
 import org.apache.hadoop.util.functional.CallableRaisingIOE;
 
@@ -286,25 +285,26 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
   Configuration getConf();
 
   /**
-   * Create a S3 Select request for the destination path.
+   * Create a S3 Select request builder for the destination path.
    * This does not build the query.
    * @param path pre-qualified path for query
-   * @return the request
+   * @return the request builder
    */
-  SelectObjectContentRequest newSelectRequest(Path path);
+  SelectObjectContentRequest.Builder newSelectRequestBuilder(Path path);
 
   /**
    * Execute an S3 Select operation.
    * On a failure, the request is only logged at debug to avoid the
    * select exception being printed.
-   * @param source source for selection
+   *
+   * @param source  source for selection
    * @param request Select request to issue.
-   * @param action the action for use in exception creation
+   * @param action  the action for use in exception creation
    * @return response
    * @throws IOException failure
    */
   @Retries.RetryTranslated
-  SelectObjectContentResult select(
+  SelectEventStreamPublisher select(
       Path source,
       SelectObjectContentRequest request,
       String action)

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -22,9 +22,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
-import com.amazonaws.services.s3.model.SSECustomerKey;
-import com.amazonaws.services.s3.model.SelectObjectContentRequest;
-
 import org.apache.hadoop.fs.PathIOException;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
@@ -46,6 +43,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
@@ -77,14 +75,6 @@ public interface RequestFactory {
    * @return an ACL, if any
    */
   ObjectCannedACL getCannedACL();
-
-  /**
-   * Create the SSE-C structure for the AWS SDK, if the encryption secrets
-   * contain the information/settings for this.
-   * This will contain a secret extracted from the bucket/configuration.
-   * @return an optional customer key.
-   */
-  Optional<SSECustomerKey> generateSSECustomerKey();
 
   /**
    * Get the encryption algorithm of this endpoint.
@@ -214,12 +204,12 @@ public interface RequestFactory {
       long size) throws PathIOException;
 
   /**
-   * Create a S3 Select request for the destination object.
+   * Create a S3 Select request builder for the destination object.
    * This does not build the query.
    * @param key object key
-   * @return the request
+   * @return the request builder
    */
-  SelectObjectContentRequest newSelectRequest(String key);
+  SelectObjectContentRequest.Builder newSelectRequestBuilder(String key);
 
   /**
    * Create the (legacy) V1 list request builder.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/BlockingEnumeration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/BlockingEnumeration.java
@@ -1,0 +1,114 @@
+package org.apache.hadoop.fs.s3a.select;
+
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.exception.SdkException;
+
+public final class BlockingEnumeration<T> implements Enumeration<T> {
+  private static final class Token<T> {
+    public T element;
+    public Throwable error;
+
+    public Token() {
+    }
+
+    public Token(T element) {
+      this.element = element;
+    }
+
+    public Token(Throwable error) {
+      this.error = error;
+    }
+  }
+
+  private final Token<T> END_TOKEN = new Token<>();
+  private final BlockingQueue<Token<T>> blockingQueue;
+  private Token<T> current = null;
+
+  public BlockingEnumeration(SdkPublisher<T> publisher, final int limit) {
+    this.blockingQueue = new LinkedBlockingQueue<>(limit);
+    publisher.subscribe(new Subscriber<T>() {
+      private Subscription subscription;
+
+      @Override
+      public void onSubscribe(Subscription s) {
+        this.subscription = s;
+        this.subscription.request(limit);
+      }
+
+      @Override
+      public void onNext(T t) {
+        enqueue(new Token<>(t));
+        subscription.request(1);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        enqueue(new Token<>(t));
+      }
+
+      @Override
+      public void onComplete() {
+        enqueue(END_TOKEN);
+      }
+
+      private void enqueue(Token<T> token) {
+        try {
+          blockingQueue.put(token);
+        } catch (InterruptedException e) {
+          // TODO: log?
+        }
+      }
+    });
+  }
+
+  public BlockingEnumeration(SdkPublisher<T> publisher,
+      final int limit,
+      T firstElement) {
+    this(publisher, limit);
+    this.current = new Token<>(firstElement);
+  }
+
+  @Override
+  public boolean hasMoreElements() {
+    if (current == null) {
+      current = dequeue();
+    }
+    return current != END_TOKEN;
+  }
+
+  @Override
+  public T nextElement() {
+    if (current == null) {
+      current = dequeue();
+    }
+    if (current == END_TOKEN) {
+      throw new NoSuchElementException();
+    }
+    if (current.error != null) {
+      if (current.error instanceof SdkException) {
+        throw (SdkException)current.error;
+      } else {
+        throw SdkException.create("Unexpected error", current.error);
+      }
+    }
+    T element = current.element;
+    current = null;
+    return element;
+  }
+
+  private Token<T> dequeue() {
+    try {
+      return blockingQueue.take();
+    } catch (InterruptedException e) {
+      // TODO: log?
+      return END_TOKEN;
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectBinding.java
@@ -21,13 +21,6 @@ package org.apache.hadoop.fs.s3a.select;
 import java.io.IOException;
 import java.util.Locale;
 
-import com.amazonaws.services.s3.model.CSVInput;
-import com.amazonaws.services.s3.model.CSVOutput;
-import com.amazonaws.services.s3.model.ExpressionType;
-import com.amazonaws.services.s3.model.InputSerialization;
-import com.amazonaws.services.s3.model.OutputSerialization;
-import com.amazonaws.services.s3.model.QuoteFields;
-import com.amazonaws.services.s3.model.SelectObjectContentRequest;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +34,14 @@ import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
 import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
+
+import software.amazon.awssdk.services.s3.model.CSVInput;
+import software.amazon.awssdk.services.s3.model.CSVOutput;
+import software.amazon.awssdk.services.s3.model.ExpressionType;
+import software.amazon.awssdk.services.s3.model.InputSerialization;
+import software.amazon.awssdk.services.s3.model.OutputSerialization;
+import software.amazon.awssdk.services.s3.model.QuoteFields;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
 
 import static org.apache.hadoop.util.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -145,9 +146,9 @@ public class SelectBinding {
     Preconditions.checkState(isEnabled(),
         "S3 Select is not enabled for %s", path);
 
-    SelectObjectContentRequest request = operations.newSelectRequest(path);
+    SelectObjectContentRequest.Builder request = operations.newSelectRequestBuilder(path);
     buildRequest(request, expression, builderOptions);
-    return request;
+    return request.build();
   }
 
   /**
@@ -175,14 +176,14 @@ public class SelectBinding {
     }
     boolean sqlInErrors = builderOptions.getBoolean(SELECT_ERRORS_INCLUDE_SQL,
         errorsIncludeSql);
-    String expression = request.getExpression();
+    String expression = request.expression();
     final String errorText = sqlInErrors ? expression : "Select";
     if (sqlInErrors) {
       LOG.info("Issuing SQL request {}", expression);
     }
+    SelectEventStreamPublisher selectPublisher = operations.select(path, request, errorText);
     return new SelectInputStream(readContext,
-        objectAttributes,
-        operations.select(path, request, errorText));
+        objectAttributes, selectPublisher);
   }
 
   /**
@@ -197,14 +198,14 @@ public class SelectBinding {
    *   <li>The default values in {@link SelectConstants}</li>
    * </ol>
    *
-   * @param request request to build up
+   * @param requestBuilder request to build up
    * @param expression SQL expression
    * @param builderOptions the options which came in from the openFile builder.
    * @throws IllegalArgumentException if an option is somehow invalid.
    * @throws IOException if an option is somehow invalid.
    */
   void buildRequest(
-      final SelectObjectContentRequest request,
+      final SelectObjectContentRequest.Builder requestBuilder,
       final String expression,
       final Configuration builderOptions)
       throws IllegalArgumentException, IOException {
@@ -212,7 +213,6 @@ public class SelectBinding {
         "No expression provided in parameter " + SELECT_SQL);
 
     final Configuration ownerConf = operations.getConf();
-
 
     String inputFormat = builderOptions.get(SELECT_INPUT_FORMAT,
         SELECT_FORMAT_CSV).toLowerCase(Locale.ENGLISH);
@@ -224,34 +224,24 @@ public class SelectBinding {
     Preconditions.checkArgument(SELECT_FORMAT_CSV.equals(outputFormat),
         "Unsupported output format %s", outputFormat);
 
-    request.setExpressionType(ExpressionType.SQL);
-    request.setExpression(expandBackslashChars(expression));
+    requestBuilder.expressionType(ExpressionType.SQL);
+    requestBuilder.expression(expandBackslashChars(expression));
 
-    InputSerialization inputSerialization = buildCsvInputRequest(ownerConf,
-        builderOptions);
-    String compression = opt(builderOptions,
-        ownerConf,
-        SELECT_INPUT_COMPRESSION,
-        COMPRESSION_OPT_NONE,
-        true).toUpperCase(Locale.ENGLISH);
-    if (isNotEmpty(compression)) {
-      inputSerialization.setCompressionType(compression);
-    }
-    request.setInputSerialization(inputSerialization);
-
-    request.setOutputSerialization(buildCSVOutput(ownerConf, builderOptions));
-
+    requestBuilder.inputSerialization(
+        buildCsvInput(ownerConf, builderOptions));
+    requestBuilder.outputSerialization(
+        buildCSVOutput(ownerConf, builderOptions));
   }
 
   /**
-   * Build the CSV input request.
+   * Build the CSV input format for a request.
    * @param ownerConf FS owner configuration
    * @param builderOptions options on the specific request
-   * @return the constructed request
+   * @return the input format
    * @throws IllegalArgumentException argument failure
    * @throws IOException validation failure
    */
-  public InputSerialization buildCsvInputRequest(
+  public InputSerialization buildCsvInput(
       final Configuration ownerConf,
       final Configuration builderOptions)
       throws IllegalArgumentException, IOException {
@@ -283,28 +273,35 @@ public class SelectBinding {
         CSV_INPUT_QUOTE_ESCAPE_CHARACTER_DEFAULT);
 
     // CSV input
-    CSVInput csv = new CSVInput();
-    csv.setFieldDelimiter(fieldDelimiter);
-    csv.setRecordDelimiter(recordDelimiter);
-    csv.setComments(commentMarker);
-    csv.setQuoteCharacter(quoteCharacter);
+    CSVInput.Builder csvBuilder = CSVInput.builder()
+        .fieldDelimiter(fieldDelimiter)
+        .recordDelimiter(recordDelimiter)
+        .comments(commentMarker)
+        .quoteCharacter(quoteCharacter);
     if (StringUtils.isNotEmpty(quoteEscapeCharacter)) {
-      csv.setQuoteEscapeCharacter(quoteEscapeCharacter);
+      csvBuilder.quoteEscapeCharacter(quoteEscapeCharacter);
     }
-    csv.setFileHeaderInfo(headerInfo);
+    csvBuilder.fileHeaderInfo(headerInfo);
 
-    InputSerialization inputSerialization = new InputSerialization();
-    inputSerialization.setCsv(csv);
-
-    return inputSerialization;
-
+    InputSerialization.Builder inputSerialization =
+        InputSerialization.builder()
+            .csv(csvBuilder.build());
+    String compression = opt(builderOptions,
+        ownerConf,
+        SELECT_INPUT_COMPRESSION,
+        COMPRESSION_OPT_NONE,
+        true).toUpperCase(Locale.ENGLISH);
+    if (isNotEmpty(compression)) {
+      inputSerialization.compressionType(compression);
+    }
+    return inputSerialization.build();
   }
 
   /**
-   * Build CSV output for a request.
+   * Build CSV output format for a request.
    * @param ownerConf FS owner configuration
    * @param builderOptions options on the specific request
-   * @return the constructed request
+   * @return the output format
    * @throws IllegalArgumentException argument failure
    * @throws IOException validation failure
    */
@@ -333,21 +330,19 @@ public class SelectBinding {
         CSV_OUTPUT_QUOTE_FIELDS,
         CSV_OUTPUT_QUOTE_FIELDS_ALWAYS).toUpperCase(Locale.ENGLISH);
 
-    // output is CSV, always
-    OutputSerialization outputSerialization
-        = new OutputSerialization();
-    CSVOutput csvOut = new CSVOutput();
-    csvOut.setQuoteCharacter(quoteCharacter);
-    csvOut.setQuoteFields(
-        QuoteFields.fromValue(quoteFields));
-    csvOut.setFieldDelimiter(fieldDelimiter);
-    csvOut.setRecordDelimiter(recordDelimiter);
+    CSVOutput.Builder csvOutputBuilder = CSVOutput.builder()
+        .quoteCharacter(quoteCharacter)
+        .quoteFields(QuoteFields.fromValue(quoteFields))
+        .fieldDelimiter(fieldDelimiter)
+        .recordDelimiter(recordDelimiter);
     if (!quoteEscapeCharacter.isEmpty()) {
-      csvOut.setQuoteEscapeCharacter(quoteEscapeCharacter);
+      csvOutputBuilder.quoteEscapeCharacter(quoteEscapeCharacter);
     }
 
-    outputSerialization.setCsv(csvOut);
-    return outputSerialization;
+    // output is CSV, always
+    return OutputSerialization.builder()
+        .csv(csvOutputBuilder.build())
+        .build();
   }
 
   /**
@@ -359,18 +354,18 @@ public class SelectBinding {
   public static String toString(final SelectObjectContentRequest request) {
     StringBuilder sb = new StringBuilder();
     sb.append("SelectObjectContentRequest{")
-        .append("bucket name=").append(request.getBucketName())
-        .append("; key=").append(request.getKey())
-        .append("; expressionType=").append(request.getExpressionType())
-        .append("; expression=").append(request.getExpression());
-    InputSerialization input = request.getInputSerialization();
+        .append("bucket name=").append(request.bucket())
+        .append("; key=").append(request.key())
+        .append("; expressionType=").append(request.expressionType())
+        .append("; expression=").append(request.expression());
+    InputSerialization input = request.inputSerialization();
     if (input != null) {
       sb.append("; Input")
           .append(input.toString());
     } else {
       sb.append("; Input Serialization: none");
     }
-    OutputSerialization out = request.getOutputSerialization();
+    OutputSerialization out = request.outputSerialization();
     if (out != null) {
       sb.append("; Output")
           .append(out.toString());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectEventStreamPublisher.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectEventStreamPublisher.java
@@ -1,0 +1,84 @@
+package org.apache.hadoop.fs.s3a.select;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.model.EndEvent;
+import software.amazon.awssdk.services.s3.model.RecordsEvent;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentEventStream;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentResponse;
+import software.amazon.awssdk.utils.ToString;
+import software.amazon.awssdk.utils.Validate;
+
+public final class SelectEventStreamPublisher implements
+    SdkPublisher<SelectObjectContentEventStream> {
+
+  private final CompletableFuture<Void> future;
+  private final SelectObjectContentResponse response;
+  private final SdkPublisher<SelectObjectContentEventStream> publisher;
+
+  public SelectEventStreamPublisher(
+      CompletableFuture<Void> future,
+      SelectObjectContentResponse response,
+      SdkPublisher<SelectObjectContentEventStream> publisher) {
+    this.future = Validate.paramNotNull(future, "future");
+    this.response = Validate.paramNotNull(response, "response");
+    this.publisher = Validate.paramNotNull(publisher, "publisher");
+  }
+
+  public void cancel() {
+    future.cancel(true);
+  }
+
+  public SelectObjectContentResponse response() {
+    return response;
+  }
+
+  @Override
+  public void subscribe(Subscriber<? super SelectObjectContentEventStream> subscriber) {
+    publisher.subscribe(subscriber);
+  }
+
+  @Override
+  public String toString() {
+    return ToString.builder("SelectObjectContentEventStream")
+        .add("response", response)
+        .add("publisher", publisher)
+        .build();
+  }
+
+  public AbortableInputStream toRecordsInputStream(Consumer<EndEvent> onEndEvent) {
+    SdkPublisher<InputStream> recordInputStreams = this.publisher
+        .filter(e -> {
+          if (e instanceof RecordsEvent) {
+            return true;
+          } else if (e instanceof EndEvent) {
+            onEndEvent.accept((EndEvent) e);
+          }
+          return false;
+        })
+        .map(e -> ((RecordsEvent) e).payload().asInputStream());
+
+    return AbortableInputStream.create(
+        new SequenceInputStream(
+            new BlockingEnumeration(recordInputStreams, 1,
+                EMPTY_STREAM)),
+        this::cancel);
+  }
+
+  private static final InputStream EMPTY_STREAM =
+      new ByteArrayInputStream(new byte[0]);
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectObjectContentHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectObjectContentHelper.java
@@ -1,0 +1,81 @@
+package org.apache.hadoop.fs.s3a.select;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentEventStream;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentResponse;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentResponseHandler;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.S3AUtils;
+
+import static org.apache.hadoop.fs.s3a.WriteOperationHelper.WriteOperationHelperCallbacks;
+
+public final class SelectObjectContentHelper {
+
+  public static SelectEventStreamPublisher select(
+      WriteOperationHelperCallbacks writeOperationHelperCallbacks,
+      Path source,
+      SelectObjectContentRequest request,
+      String action)
+      throws IOException {
+    try {
+      Handler handler = new Handler();
+      CompletableFuture<Void> operationFuture =
+          writeOperationHelperCallbacks.selectObjectContent(request, handler);
+      return handler.eventPublisher(operationFuture).join();
+    } catch (Throwable e) {
+      if (e instanceof CompletionException) {
+        e = e.getCause();
+      }
+      IOException translated;
+      if (e instanceof SdkException) {
+        translated = S3AUtils.translateExceptionV2(action, source.toString(),
+            (SdkException)e);
+      } else {
+        translated = new IOException(e);
+      }
+      throw translated;
+    }
+  }
+
+  private static class Handler implements SelectObjectContentResponseHandler {
+    private volatile CompletableFuture<Pair<SelectObjectContentResponse,
+        SdkPublisher<SelectObjectContentEventStream>>> future =
+        new CompletableFuture<>();
+
+    private volatile SelectObjectContentResponse response;
+
+    public CompletableFuture<SelectEventStreamPublisher> eventPublisher(
+        CompletableFuture<Void> operationFuture) {
+      return future.thenApply(p ->
+          new SelectEventStreamPublisher(operationFuture,
+              p.getLeft(), p.getRight()));
+    }
+
+    @Override
+    public void responseReceived(SelectObjectContentResponse response) {
+      this.response = response;
+    }
+
+    @Override
+    public void onEventStream(SdkPublisher<SelectObjectContentEventStream> publisher) {
+      future.complete(Pair.of(response, publisher));
+    }
+
+    @Override
+    public void exceptionOccurred(Throwable error) {
+      future.completeExceptionally(error);
+    }
+
+    @Override
+    public void complete() {
+    }
+  }
+}

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3ClientFactory.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.MultipartUploadListing;
 import com.amazonaws.services.s3.model.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 /**
@@ -55,6 +56,12 @@ public class MockS3ClientFactory implements S3ClientFactory {
   @Override
   public S3Client createS3ClientV2(URI uri, final S3ClientCreationParameters parameters) {
     S3Client s3 = mock(S3Client.class);
+    return s3;
+  }
+
+  @Override
+  public S3AsyncClient createS3AsyncClient(URI uri, final S3ClientCreationParameters parameters) {
+    S3AsyncClient s3 = mock(S3AsyncClient.class);
     return s3;
   }
 }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
@@ -188,7 +188,7 @@ public class TestRequestFactory extends AbstractHadoopTestBase {
         PutObjectOptions.keepingDirs(), -1, true));
     a(factory.newPutObjectRequestBuilder(path,
         PutObjectOptions.deletingDirs(), 1024, false));
-    a(factory.newSelectRequest(path));
+    a(factory.newSelectRequestBuilder(path));
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/MinimalWriteOperationHelperCallbacks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/MinimalWriteOperationHelperCallbacks.java
@@ -18,12 +18,15 @@
 
 package org.apache.hadoop.fs.s3a.test;
 
-import com.amazonaws.services.s3.model.SelectObjectContentRequest;
-import com.amazonaws.services.s3.model.SelectObjectContentResult;
+import java.util.concurrent.CompletableFuture;
 
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentResponse;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentResponseHandler;
 
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
 
 /**
@@ -33,7 +36,9 @@ public class MinimalWriteOperationHelperCallbacks
     implements WriteOperationHelper.WriteOperationHelperCallbacks {
 
   @Override
-  public SelectObjectContentResult selectObjectContent(SelectObjectContentRequest request) {
+  public CompletableFuture<Void> selectObjectContent(
+      SelectObjectContentRequest request,
+      SelectObjectContentResponseHandler th) {
     return null;
   }
 


### PR DESCRIPTION
Rebase + rework of the changes in https://github.com/ahmarsuhail/hadoop/pull/12

A few issues remain open:

Configuration - Since Select is only available on the Async client, we have to instantiate a second client, which leads to some code duplication. Also we need to investigate NTLM support.

SelectInputStream - v1 implementation could simply wrap the getRecordsInputStream() result. In v2, instead, we have to  consume an asynchronous event stream and expose it as an input stream. The current naive implementation is only intended as a temporary placeholder while we investigate the issue.