### PR TITLE
Try to refactor SelectObjectContentHelper

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/WriteOperations.java
@@ -285,32 +285,6 @@ public interface WriteOperations extends AuditSpanSource, Closeable {
   Configuration getConf();
 
   /**
-   * Create a S3 Select request builder for the destination path.
-   * This does not build the query.
-   * @param path pre-qualified path for query
-   * @return the request builder
-   */
-  SelectObjectContentRequest.Builder newSelectRequestBuilder(Path path);
-
-  /**
-   * Execute an S3 Select operation.
-   * On a failure, the request is only logged at debug to avoid the
-   * select exception being printed.
-   *
-   * @param source  source for selection
-   * @param request Select request to issue.
-   * @param action  the action for use in exception creation
-   * @return response
-   * @throws IOException failure
-   */
-  @Retries.RetryTranslated
-  SelectEventStreamPublisher select(
-      Path source,
-      SelectObjectContentRequest request,
-      String action)
-      throws IOException;
-
-  /**
    * Increment the write operation counter
    * of the filesystem.
    */

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectObjectContentHelper.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/select/SelectObjectContentHelper.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.async.SdkPublisher;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.model.SelectObjectContentEventStream;
@@ -30,27 +32,182 @@ import software.amazon.awssdk.services.s3.model.SelectObjectContentResponse;
 import software.amazon.awssdk.services.s3.model.SelectObjectContentResponseHandler;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.s3a.Invoker;
+import org.apache.hadoop.fs.s3a.Retries;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.hadoop.fs.s3a.S3ARetryPolicy;
 import org.apache.hadoop.fs.s3a.S3AUtils;
+import org.apache.hadoop.fs.s3a.api.RequestFactory;
+import org.apache.hadoop.fs.s3a.impl.StoreContext;
+import org.apache.hadoop.fs.store.audit.AuditSpan;
+import org.apache.hadoop.util.DurationInfo;
+import org.apache.hadoop.util.Preconditions;
 
-import static org.apache.hadoop.fs.s3a.WriteOperationHelper.WriteOperationHelperCallbacks;
+import static org.apache.hadoop.fs.store.audit.AuditingFunctions.withinAuditSpan;
+import static org.apache.hadoop.util.Preconditions.checkNotNull;
 
 /**
  * Helper for SelectObjectContent queries against an S3 Bucket.
+ * <p>
+ * This API is for internal use only.
+ * Span scoping: This helper is instantiated with span; it will be used
+ * before operations which query S3
  */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
 public final class SelectObjectContentHelper {
-  
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SelectObjectContentHelper.class);
+
+  /**
+   * Owning filesystem.
+   */
+  private final S3AFileSystem owner;
+
+  /**
+   * Invoker for operations; uses the S3A retry policy and calls int
+   * {@link #operationRetried(String, Exception, int, boolean)} on retries.
+   */
+  private final Invoker invoker;
+
+  /** Configuration of the owner. This is a reference, not a copy. */
+  private final Configuration conf;
+
+  /** Bucket of the owner FS. */
+  private final String bucket;
+
+  /**
+   * Store Context; extracted from owner.
+   */
+  private final StoreContext storeContext;
+
+  /**
+   * Audit Span.
+   */
+  private AuditSpan auditSpan;
+
+  /**
+   * Factory for AWS requests.
+   */
+  private final RequestFactory requestFactory;
+
+  /**
+   * Callbacks for this helper.
+   */
+  private final SelectObjectContentHelperCallbacks helperCallbacks;
+
+  /**
+   * Constructor.
+   * @param owner owner FS creating the helper
+   * @param conf Configuration object
+   * @param auditSpan span to activate
+   * @param SelectObjectContentHelperCallbacks callbacks used by SelectObjectContentHelper
+   */
+  public SelectObjectContentHelper(S3AFileSystem owner,
+      Configuration conf,
+      final AuditSpan auditSpan,
+      final SelectObjectContentHelperCallbacks helperCallbacks) {
+    this.owner = owner;
+    this.invoker = new Invoker(new S3ARetryPolicy(conf),
+        this::operationRetried);
+    this.conf = conf;
+    this.storeContext = owner.createStoreContext();
+    this.bucket = owner.getBucket();
+    this.auditSpan = checkNotNull(auditSpan);
+    this.requestFactory = owner.getRequestFactory();
+    this.helperCallbacks = helperCallbacks;
+  }
+
+  /**
+   * Callback from {@link Invoker} when an operation is retried.
+   * @param text text of the operation
+   * @param ex exception
+   * @param retries number of retries
+   * @param idempotent is the method idempotent
+   */
+  void operationRetried(String text, Exception ex, int retries,
+      boolean idempotent) {
+    LOG.info("{}: Retried {}: {}", text, retries, ex.toString());
+    LOG.debug("Stack", ex);
+    owner.operationRetried(text, ex, retries, idempotent);
+  }
+
+  /**
+   * Get the configuration of this instance; essentially the owning
+   * filesystem configuration.
+   * @return the configuration.
+   */
+  public Configuration getConf() {
+    return conf;
+  }
+
+  /**
+   * Create a S3 Select request builder for the destination path.
+   * This does not build the query.
+   * @param path pre-qualified path for query
+   * @return the request builder
+   */
+  public SelectObjectContentRequest.Builder newSelectRequestBuilder(Path path) {
+    try (AuditSpan span = auditSpan) {
+      return requestFactory.newSelectRequestBuilder(
+          storeContext.pathToKey(path));
+    }
+  }
+
   /**
    * Execute an S3 Select operation.
-   * @param writeOperationHelperCallbacks helper callbacks
+   * On a failure, the request is only logged at debug to avoid the
+   * select exception being printed.
+   *
    * @param source  source for selection
    * @param request Select request to issue.
    * @param action  the action for use in exception creation
-   * @return the select response event stream publisher
-   * @throws IOException on failure
+   * @return response
+   * @throws IOException failure
    */
-  public static SelectEventStreamPublisher select(
-      WriteOperationHelperCallbacks writeOperationHelperCallbacks,
+  @Retries.RetryTranslated
+  public SelectEventStreamPublisher select(
+      final Path source,
+      final SelectObjectContentRequest request,
+      final String action)
+      throws IOException {
+    // no setting of span here as the select binding is (statically) created
+    // without any span.
+    String bucketName = request.bucket();
+    Preconditions.checkArgument(bucket.equals(bucketName),
+        "wrong bucket: %s", bucketName);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Initiating select call {} {}",
+          source, request.expression());
+      LOG.debug(SelectBinding.toString(request));
+    }
+    return invoker.retry(
+        action,
+        source.toString(),
+        true,
+        withinAuditSpan(auditSpan, () -> {
+          try (DurationInfo ignored =
+              new DurationInfo(LOG, "S3 Select operation")) {
+            try {
+              return selectInternal(source, request, action);
+            } catch (Throwable e) {
+              LOG.error("Failure of S3 Select request against {}",
+                  source);
+              LOG.debug("S3 Select request against {}:\n{}",
+                  source,
+                  SelectBinding.toString(request),
+                  e);
+              throw e;
+            }
+          }
+        }));
+  }
+
+  private SelectEventStreamPublisher selectInternal(
       Path source,
       SelectObjectContentRequest request,
       String action)
@@ -58,7 +215,7 @@ public final class SelectObjectContentHelper {
     try {
       Handler handler = new Handler();
       CompletableFuture<Void> selectOperationFuture =
-          writeOperationHelperCallbacks.selectObjectContent(request, handler);
+          helperCallbacks.selectObjectContent(request, handler);
       return handler.eventPublisher(selectOperationFuture).join();
     } catch (Throwable e) {
       if (e instanceof CompletionException) {
@@ -73,6 +230,22 @@ public final class SelectObjectContentHelper {
       }
       throw translated;
     }
+  }
+
+  /**
+   * Callbacks for SelectObjectContentHelper.
+   */
+  public interface SelectObjectContentHelperCallbacks {
+
+    /**
+     * Initiates a select request.
+     * @param request selectObjectContent request
+     * @param responseHandler response handler
+     * @return future for the select operation
+     */
+    CompletableFuture<Void> selectObjectContent(
+        SelectObjectContentRequest request,
+        SelectObjectContentResponseHandler responseHandler);
   }
 
   private static class Handler implements SelectObjectContentResponseHandler {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/MinimalWriteOperationHelperCallbacks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/MinimalWriteOperationHelperCallbacks.java
@@ -22,9 +22,6 @@ import java.util.concurrent.CompletableFuture;
 
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
-import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
-import software.amazon.awssdk.services.s3.model.SelectObjectContentResponse;
-import software.amazon.awssdk.services.s3.model.SelectObjectContentResponseHandler;
 
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.WriteOperationHelper;
@@ -34,13 +31,6 @@ import org.apache.hadoop.fs.s3a.WriteOperationHelper;
  */
 public class MinimalWriteOperationHelperCallbacks
     implements WriteOperationHelper.WriteOperationHelperCallbacks {
-
-  @Override
-  public CompletableFuture<Void> selectObjectContent(
-      SelectObjectContentRequest request,
-      SelectObjectContentResponseHandler th) {
-    return null;
-  }
 
   @Override
   public CompleteMultipartUploadResponse completeMultipartUpload(


### PR DESCRIPTION
Attempt to separate Select support from WriteOperationHelper (& Callbacks). 

It always confused me that we had to pass around a `WriteOperationHelperCallbacks` object for Select, so I have tried to split out the two. The result seems to make sense, but I have had to add a bit of (support) code to SelectObjectContentHelper, mostly duplicated from WriteOperationHelper.

Question: Is this going in the right direction?